### PR TITLE
Moved the Controllers to the Left

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -39,6 +39,8 @@
     display: inline-block;
     transition: 0.25s all;
     opacity: 0.6;
+    /* Added Border Radius 2px to Top Corners */
+    border-radius: 2px 2px 0 0;
 }
 
 /* Moved the Controls to the Right and removed their background */
@@ -114,9 +116,7 @@ div.documents-holder > span.document {
     position: absolute;
     top: 0;
     left: 0;
-    border-width: 10px 10px 0px 0px;
-    border-style: solid;
-    border-color: white transparent transparent white;
+    /* Removed Square Corners */
     z-index: 10;
 }
 


### PR DESCRIPTION
This should improve experience and usability.
The controls on the left are prone to errors, in daily usage most users use the files tabs more than they use the extension controllers, this should not fill usable space and should have a different aspect (no background seems just right).
